### PR TITLE
Update OSM tile URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ files to override the behaviour. For example:
 
 ```yml
 overlay:
-    url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
     active: true
     opacity: 1
     position: -1

--- a/front.js
+++ b/front.js
@@ -4,7 +4,7 @@ L.K.Map.addInitHook(function () {
             title = L.DomUtil.create('h3', '', container),
             params = L.extend({
                 tms: false,
-                url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 active: false,
                 opacity: 0.5,
                 position: 1


### PR DESCRIPTION
Updated OSM tile URL. See https://github.com/openstreetmap/operations/issues/737

Use HTTPS / direct links (if HTTP redirect).